### PR TITLE
Add Automated Stale Backup Deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@googleapis/drive": "^8.6.0",
     "cron": "^3.1.6",
+    "dayjs": "^1.11.11",
+    "dotenv": "^16.4.5",
     "envalid": "^8.0.0",
     "filesize": "^10.1.0",
     "google-auth-library": "^9.6.1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@googleapis/drive": "^8.6.0",
     "cron": "^3.1.6",
     "dayjs": "^1.11.11",
-    "dotenv": "^16.4.5",
     "envalid": "^8.0.0",
     "filesize": "^10.1.0",
     "google-auth-library": "^9.6.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       dayjs:
         specifier: ^1.11.11
         version: 1.11.11
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.4.5
       envalid:
         specifier: ^8.0.0
         version: 8.0.0
@@ -93,10 +90,6 @@ packages:
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
-
-  dotenv@16.4.5:
-    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
-    engines: {node: '>=12'}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -307,8 +300,6 @@ snapshots:
       es-define-property: 1.0.0
       es-errors: 1.3.0
       gopd: 1.0.1
-
-  dotenv@16.4.5: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,481 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@googleapis/drive':
+        specifier: ^8.6.0
+        version: 8.10.0
+      cron:
+        specifier: ^3.1.6
+        version: 3.1.7
+      dayjs:
+        specifier: ^1.11.11
+        version: 1.11.11
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
+      envalid:
+        specifier: ^8.0.0
+        version: 8.0.0
+      filesize:
+        specifier: ^10.1.0
+        version: 10.1.2
+      google-auth-library:
+        specifier: ^9.6.1
+        version: 9.10.0
+    devDependencies:
+      '@types/bun':
+        specifier: latest
+        version: 1.1.3
+      typescript:
+        specifier: ^5.3.3
+        version: 5.4.5
+
+packages:
+
+  '@googleapis/drive@8.10.0':
+    resolution: {integrity: sha512-loumtaDmAn2JvU4KuFMhhtaYG1Hxw0RVS4vl+rOWMU7NAU151XYfIWFDJfFFZjvYZxH4tbsmHEnF+DKH1hQ75Q==}
+    engines: {node: '>=12.0.0'}
+
+  '@types/bun@1.1.3':
+    resolution: {integrity: sha512-i+mVz8C/lx+RprDR6Mr402iE1kmajgJPnmSfJ/NvU85sGGXSylYZ/6yc+XhVLr2E/t8o6HmjwV0evtnUOR0CFA==}
+
+  '@types/luxon@3.4.2':
+    resolution: {integrity: sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==}
+
+  '@types/node@20.12.14':
+    resolution: {integrity: sha512-scnD59RpYD91xngrQQLGkE+6UrHUPzeKZWhhjBSa3HSkwjbQc38+q3RoIVEwxQGRw3M+j5hpNAM+lgV3cVormg==}
+
+  '@types/ws@8.5.10':
+    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
+
+  agent-base@7.1.1:
+    resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
+    engines: {node: '>= 14'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bignumber.js@9.1.2:
+    resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  bun-types@1.1.9:
+    resolution: {integrity: sha512-3YuLiH4Ne/ghk7K6mHiaqCqKOMrtB0Z5p1WAskHSVgi0iMZgsARV4yGkbfi565YsStvUq6GXTWB3ga7M8cznkA==}
+
+  call-bind@1.0.7:
+    resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+
+  cron@3.1.7:
+    resolution: {integrity: sha512-tlBg7ARsAMQLzgwqVxy8AZl/qlTc5nibqYwtNGoCrd+cV+ugI+tvZC1oT/8dFH8W455YrywGykx/KMmAqOr7Jw==}
+
+  dayjs@1.11.11:
+    resolution: {integrity: sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==}
+
+  debug@4.3.5:
+    resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  envalid@8.0.0:
+    resolution: {integrity: sha512-PGeYJnJB5naN0ME6SH8nFcDj9HVbLpYIfg1p5lAyM9T4cH2lwtu2fLbozC/bq+HUUOIFxhX/LP0/GmlqPHT4tQ==}
+    engines: {node: '>=8.12'}
+
+  es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  filesize@10.1.2:
+    resolution: {integrity: sha512-Dx770ai81ohflojxhU+oG+Z2QGvKdYxgEr9OSA8UVrqhwNHjfH9A8f5NKfg83fEH8ZFA5N5llJo5T3PIoZ4CRA==}
+    engines: {node: '>= 10.4.0'}
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@6.6.0:
+    resolution: {integrity: sha512-bpOZVQV5gthH/jVCSuYuokRo2bTKOcuBiVWpjmTn6C5Agl5zclGfTljuGsQZxwwDBkli+YhZhP4TdlqTnhOezQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.0:
+    resolution: {integrity: sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==}
+    engines: {node: '>=14'}
+
+  get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+    engines: {node: '>= 0.4'}
+
+  google-auth-library@9.10.0:
+    resolution: {integrity: sha512-ol+oSa5NbcGdDqA+gZ3G3mev59OHBZksBTxY/tYwjtcp1H/scAFwJfSQU9/1RALoyZ7FslNbke8j4i3ipwlyuQ==}
+    engines: {node: '>=14'}
+
+  googleapis-common@7.2.0:
+    resolution: {integrity: sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==}
+    engines: {node: '>=14.0.0'}
+
+  gopd@1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.0.3:
+    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  https-proxy-agent@7.0.4:
+    resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
+    engines: {node: '>= 14'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  jwa@2.0.0:
+    resolution: {integrity: sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==}
+
+  jws@4.0.0:
+    resolution: {integrity: sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==}
+
+  luxon@3.4.4:
+    resolution: {integrity: sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==}
+    engines: {node: '>=12'}
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  object-inspect@1.13.1:
+    resolution: {integrity: sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==}
+
+  qs@6.12.1:
+    resolution: {integrity: sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==}
+    engines: {node: '>=0.6'}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.0.6:
+    resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
+    engines: {node: '>= 0.4'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  typescript@5.4.5:
+    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+snapshots:
+
+  '@googleapis/drive@8.10.0':
+    dependencies:
+      googleapis-common: 7.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@types/bun@1.1.3':
+    dependencies:
+      bun-types: 1.1.9
+
+  '@types/luxon@3.4.2': {}
+
+  '@types/node@20.12.14':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/ws@8.5.10':
+    dependencies:
+      '@types/node': 20.12.14
+
+  agent-base@7.1.1:
+    dependencies:
+      debug: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+
+  base64-js@1.5.1: {}
+
+  bignumber.js@9.1.2: {}
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  bun-types@1.1.9:
+    dependencies:
+      '@types/node': 20.12.14
+      '@types/ws': 8.5.10
+
+  call-bind@1.0.7:
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      set-function-length: 1.2.2
+
+  cron@3.1.7:
+    dependencies:
+      '@types/luxon': 3.4.2
+      luxon: 3.4.4
+
+  dayjs@1.11.11: {}
+
+  debug@4.3.5:
+    dependencies:
+      ms: 2.1.2
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      gopd: 1.0.1
+
+  dotenv@16.4.5: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  envalid@8.0.0:
+    dependencies:
+      tslib: 2.6.2
+
+  es-define-property@1.0.0:
+    dependencies:
+      get-intrinsic: 1.2.4
+
+  es-errors@1.3.0: {}
+
+  extend@3.0.2: {}
+
+  filesize@10.1.2: {}
+
+  function-bind@1.1.2: {}
+
+  gaxios@6.6.0:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.4
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.0:
+    dependencies:
+      gaxios: 6.6.0
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  get-intrinsic@1.2.4:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      has-proto: 1.0.3
+      has-symbols: 1.0.3
+      hasown: 2.0.2
+
+  google-auth-library@9.10.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.6.0
+      gcp-metadata: 6.1.0
+      gtoken: 7.1.0
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  googleapis-common@7.2.0:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 6.6.0
+      google-auth-library: 9.10.0
+      qs: 6.12.1
+      url-template: 2.0.8
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gopd@1.0.1:
+    dependencies:
+      get-intrinsic: 1.2.4
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.6.0
+      jws: 4.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.0
+
+  has-proto@1.0.3: {}
+
+  has-symbols@1.0.3: {}
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  https-proxy-agent@7.0.4:
+    dependencies:
+      agent-base: 7.1.1
+      debug: 4.3.5
+    transitivePeerDependencies:
+      - supports-color
+
+  is-stream@2.0.1: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.1.2
+
+  jwa@2.0.0:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.0:
+    dependencies:
+      jwa: 2.0.0
+      safe-buffer: 5.2.1
+
+  luxon@3.4.4: {}
+
+  ms@2.1.2: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  object-inspect@1.13.1: {}
+
+  qs@6.12.1:
+    dependencies:
+      side-channel: 1.0.6
+
+  safe-buffer@5.2.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+
+  side-channel@1.0.6:
+    dependencies:
+      call-bind: 1.0.7
+      es-errors: 1.3.0
+      get-intrinsic: 1.2.4
+      object-inspect: 1.13.1
+
+  tr46@0.0.3: {}
+
+  tslib@2.6.2: {}
+
+  typescript@5.4.5: {}
+
+  undici-types@5.26.5: {}
+
+  url-template@2.0.8: {}
+
+  uuid@9.0.1: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1

--- a/src/backup-gdrive.ts
+++ b/src/backup-gdrive.ts
@@ -8,103 +8,143 @@ import * as path from "path";
 import * as os from "os";
 import { filesize } from "filesize";
 import { createReadStream } from "fs";
+import dayjs from "dayjs";
 
 const auth = new JWT({
-    email: env.SERVICE_ACCOUNT.client_email,
-    key: env.SERVICE_ACCOUNT.private_key,
-    scopes: ["https://www.googleapis.com/auth/drive"],
+  email: env.SERVICE_ACCOUNT.client_email,
+  key: env.SERVICE_ACCOUNT.private_key,
+  scopes: ["https://www.googleapis.com/auth/drive"],
 });
 
 const gdrive = drive({
-    version: "v3",
-    auth: auth,
+  version: "v3",
+  auth: auth,
 });
 
+const deleteStaleBackups = async (cutOffDate: Date) => {
+  const folderAccess = await gdrive.files.get({
+    fileId: env.FOLDER_ID,
+    fields: "id",
+  });
+
+  if (!folderAccess.data.id) {
+    console.error(`No access to FOLDER_ID: ${env.FOLDER_ID}`);
+    return;
+  }
+
+  const res = await gdrive.files.list({
+    pageSize: 100,
+    fields: "nextPageToken, files(id, createdTime)",
+    q: `'${env.FOLDER_ID}' in parents and trashed=false and mimeType = 'application/gzip' and createdTime < '${cutOffDate.toISOString()}'`,
+  });
+
+  if (!res.data.files) {
+    return;
+  }
+
+  for (const file of res.data.files) {
+    if (!file.id) continue;
+    await gdrive.files.delete({ fileId: file.id });
+  }
+};
+
 const dumpToFile = async (path: string) => {
-    return new Promise((resolve, reject) => {
-        exec(`pg_dump --dbname=${env.DATABASE_URL} --format=tar | gzip > ${path}`,
-            (err, stdout, stderr) => {
-                if (err) {
-                    reject({
-                        error: err,
-                        stderr: stderr.trimEnd(),
-                    });
-                    return;
-                }
+  return new Promise((resolve, reject) => {
+    exec(
+      `pg_dump --dbname=${env.DATABASE_URL} --format=tar | gzip > ${path}`,
+      (err, stdout, stderr) => {
+        if (err) {
+          reject({
+            error: err,
+            stderr: stderr.trimEnd(),
+          });
+          return;
+        }
 
-                if (!!stderr) {
-                    console.log(stderr.trimEnd());
-                }
+        if (!!stderr) {
+          console.log(stderr.trimEnd());
+        }
 
-                const isFileValid = execSync(`gzip -cd ${path} | head -c1`).length > 0;
+        const isFileValid = execSync(`gzip -cd ${path} | head -c1`).length > 0;
 
-                if(!isFileValid) {
-                    console.error("Backup file is empty");
-                    reject("Backup file is empty");
-                    return;
-                }
+        if (!isFileValid) {
+          console.error("Backup file is empty");
+          reject("Backup file is empty");
+          return;
+        }
 
-                console.log(`Backup file size: ${filesize(statSync(path).size)}`);
-                console.log(`Backup file created at: ${path}`)
+        console.log(`Backup file size: ${filesize(statSync(path).size)}`);
+        console.log(`Backup file created at: ${path}`);
 
-                if(stdout) {
-                    console.log(stdout);
-                }
+        if (stdout) {
+          console.log(stdout);
+        }
 
-                resolve(stdout);
-            }
-        );
-    });
-}
+        resolve(stdout);
+      },
+    );
+  });
+};
 
 const pushToDrive = async (filename: string, path: string) => {
-    const folderAccess = await gdrive.files.get({
-        fileId: env.FOLDER_ID,
-        fields: "id",
-    });
+  const folderAccess = await gdrive.files.get({
+    fileId: env.FOLDER_ID,
+    fields: "id",
+  });
 
-    if (!folderAccess.data.id) {
-        console.error(`No access to FOLDER_ID: ${env.FOLDER_ID}`);
-        return;
-    }
+  if (!folderAccess.data.id) {
+    console.error(`No access to FOLDER_ID: ${env.FOLDER_ID}`);
+    return;
+  }
 
-    const fileMetadata = {
-        name: filename,
-        parents: [env.FOLDER_ID],
-    };
+  const fileMetadata = {
+    name: filename,
+    parents: [env.FOLDER_ID],
+  };
 
-    const media = {
-        mimeType: "application/gzip",
-        body: createReadStream(path)
-    };
+  const media = {
+    mimeType: "application/gzip",
+    body: createReadStream(path),
+  };
 
-    await gdrive.files.create({
-        requestBody: fileMetadata,
-        media: media,
-    });
-}
+  await gdrive.files.create({
+    requestBody: fileMetadata,
+    media: media,
+  });
+};
 
 export async function run() {
-    try {
-        const timestamp = new Date().toISOString().replace(/:/g, "-").replace(".", "-");
-
-        const filename = `${env.FILE_PREFIX}${timestamp}.tar.gz`;
-        const filepath = path.join(os.tmpdir(), filename);
-
-        console.log(`Starting backup of ${filename}`);
-
-        await dumpToFile(filepath);
-
-        console.log("Backup done! Uploading to Google Drive...");
-
-        await pushToDrive(filename, filepath);
-
-        console.log("Backup uploaded to Google Drive!");
-
-        await unlink(filepath);
-
-        console.log("All done!");
-    } catch (err) {
-        console.error("Something went wrong:", err);
+  try {
+    if (env.RETENTION && env.RETENTION !== "disabled") {
+      console.log(`Deleting old backups older than a ${env.RETENTION}`);
+      const cutOffDate = dayjs().subtract(1, env.RETENTION).toDate();
+      await deleteStaleBackups(cutOffDate);
+      console.log(`Delete complete! Procceding with backup.`);
     }
+
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/:/g, "-")
+      .replace(".", "-");
+
+    const filename = `${env.FILE_PREFIX}${timestamp}.tar.gz`;
+
+    const filepath = path.join(os.tmpdir(), filename);
+
+    console.log(`Starting backup of ${filename}`);
+
+    await dumpToFile(filepath);
+
+    console.log("Backup done! Uploading to Google Drive...");
+
+    await pushToDrive(filename, filepath);
+
+    console.log("Backup uploaded to Google Drive!");
+
+    await unlink(filepath);
+
+    console.log("All done!");
+  } catch (err) {
+    console.error("Something went wrong:", err);
+  }
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,21 +1,25 @@
-import { cleanEnv, str, json, bool } from 'envalid';
+import { cleanEnv, str, json, bool } from "envalid";
 
 export const env = cleanEnv(process.env, {
-    SERVICE_ACCOUNT: json<{
-        type: string;
-        project_id: string;
-        private_key_id: string;
-        private_key: string;
-        client_email: string;
-        client_id: string;
-        auth_uri: string;
-        token_uri: string;
-        auth_provider_x509_cert_url: string;
-        client_x509_cert_url: string;
-    }>(),
-    FILE_PREFIX: str({ default: 'db-backup-' }),
-    DATABASE_URL: str(),
-    FOLDER_ID: str(),
-    CRON_EXPRESSION: str({ default: '0 0 * * *' }),
-    RUN_ON_START: bool({ default: true })
+  SERVICE_ACCOUNT: json<{
+    type: string;
+    project_id: string;
+    private_key_id: string;
+    private_key: string;
+    client_email: string;
+    client_id: string;
+    auth_uri: string;
+    token_uri: string;
+    auth_provider_x509_cert_url: string;
+    client_x509_cert_url: string;
+  }>(),
+  FILE_PREFIX: str({ default: "db-backup-" }),
+  RETENTION: str({
+    choices: ["week", "month", "year", "disabled"],
+    default: "disabled",
+  }),
+  DATABASE_URL: str(),
+  FOLDER_ID: str(),
+  CRON_EXPRESSION: str({ default: "0 0 * * *" }),
+  RUN_ON_START: bool({ default: true }),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { CronJob } from "cron";
 import { env } from "./env";
 import { run } from "./backup-gdrive";
@@ -5,36 +6,37 @@ import { run } from "./backup-gdrive";
 const isUsingCron = env.CRON_EXPRESSION !== "-1";
 
 const main = async () => {
-    if (
-        !env.FOLDER_ID ||
-        !env.DATABASE_URL ||
-        !env?.SERVICE_ACCOUNT?.private_key ||
-        !env?.SERVICE_ACCOUNT?.client_email
-    ) {
-        console.error("Missing required environment variables (FOLDER_ID, DATABASE_URL, SERVICE_ACCOUNT.PRIVATE_KEY, SERVICE_ACCOUNT.CLIENT_EMAIL), please check your Environment.");
-        return
-    }
-
-    if(!isUsingCron) {
-        console.log(`Running backup once.`);
-        await run();
-        return;
-    }
-
-    console.log(`Running backup every ${env.CRON_EXPRESSION}.`);
-
-    const cron = new CronJob(
-        env.CRON_EXPRESSION,
-        run
+  if (
+    !env.FOLDER_ID ||
+    !env.DATABASE_URL ||
+    !env?.SERVICE_ACCOUNT?.private_key ||
+    !env?.SERVICE_ACCOUNT?.client_email
+  ) {
+    console.error(
+      "Missing required environment variables (FOLDER_ID, DATABASE_URL, SERVICE_ACCOUNT.PRIVATE_KEY, SERVICE_ACCOUNT.CLIENT_EMAIL), please check your Environment.",
     );
+    return;
+  }
 
-    if (env.RUN_ON_START) {
-        await run();
-    } else {
-        console.log(`Skipping initial backup, enable with RUN_ON_START=true if you want to run a backup on start.`);
-    }
+  if (!isUsingCron) {
+    console.log(`Running backup once.`);
+    await run();
+    return;
+  }
 
-    cron.start();
-}
+  console.log(`Running backup every ${env.CRON_EXPRESSION}.`);
+
+  const cron = new CronJob(env.CRON_EXPRESSION, run);
+
+  if (env.RUN_ON_START) {
+    await run();
+  } else {
+    console.log(
+      `Skipping initial backup, enable with RUN_ON_START=true if you want to run a backup on start.`,
+    );
+  }
+
+  cron.start();
+};
 
 void main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import "dotenv/config";
 import { CronJob } from "cron";
 import { env } from "./env";
 import { run } from "./backup-gdrive";


### PR DESCRIPTION
## Summary
This pull request introduces a `RETENTION` environment variable to control the automated deletion of stale backups. The `RETENTION` variable can be set to one of the following values: `week`, `month`, `year`, or `disabled` (default). 

## Changes
- Added `RETENTION` env variable to specify the retention period.
- Updated the `run` function to check if `RETENTION` is valid (i.e., not null or `disabled`) and then call the `deleteStaleBackups` function.
  
## Notes
- The feature uses `dayjs` for date manipulation because it is easier. But I'm sure it can be done without the new dep.